### PR TITLE
DOC: Added pre-commit link inside the guideline

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -216,6 +216,16 @@ should already exist.
    python setup.py build_ext -j 4
    python -m pip install -e . --no-build-isolation --no-use-pep517
 
+**Installing Pre-commit**
+
+In the root directory of the project run the below command to install the pre-commit tool. For more details on installing and usage of pre-commit,visit
+`here <https://pandas.pydata.org/pandas-docs/stable/development/contributing_codebase.html#pre-commit>`__.
+
+.. code-block:: powershell
+
+   # Install pre-commit
+   pre-commit install
+
 Option 2: creating an environment using Docker
 ----------------------------------------------
 


### PR DESCRIPTION
- [x] closes #48941

Updated the Guidelines to include a link that redirects to Pre-commit installation. The link is included with some text to help developers to setup the environment.
